### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,13 @@ jobs:
           name: Run pylint
           command: |
             . venv/bin/activate
+            export PYTHONPATH=.
             pylint devchat
       - run:
           name: Run pytest
           command: |
             . venv/bin/activate
+            export PYTHONPATH=.
             pytest
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.11
+      - image: python:3.11
     steps:
       - checkout
       - run:
@@ -25,7 +25,12 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            . venv/bin
+            . venv/bin/activate
+            pytest
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  build-deploy:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,22 +5,27 @@ version: 2.1
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/configuration-reference/#executor-job
+  build:
     docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/configuration-reference/#steps
+      - image: circleci/python:3.11
     steps:
       - checkout
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: Install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install pylint pytest
+      - run:
+          name: Run pylint
+          command: |
+            . venv/bin/activate
+            pylint devchat
+      - run:
+          name: Run pytest
+          command: |
+            . venv/bin
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
-workflows:
-  say-hello-workflow:
-    jobs:
-      - say-hello


### PR DESCRIPTION
**Summary**
This pull request updates the CircleCI configuration to run pylint and pytest for the devchat project. It also ensures the correct Python image is used and sets the PYTHONPATH to fix module import errors during test execution.

**Changes**
- Update the CircleCI configuration to run pylint and pytest, replacing the original say-hello job and workflow with a build job and workflow.
- Replace the CircleCI Python image with the official Python 3.11 image to resolve the manifest not found error.
- Set the PYTHONPATH environment variable to the project root directory to fix the ModuleNotFoundError for the devchat package during test collection.